### PR TITLE
Fix Select.Item empty value error in agent components

### DIFF
--- a/src/components/agents/email-agent-create-modal.tsx
+++ b/src/components/agents/email-agent-create-modal.tsx
@@ -206,7 +206,7 @@ export function EmailAgentCreateModal({ workspaceId }: EmailAgentCreateModalProp
                                     />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="">No client selected</SelectItem>
+                                    <SelectItem value="none">No client selected</SelectItem>
                                     {clients.map((client) => (
                                         <SelectItem key={client.id} value={client.id}>
                                             {client.name}

--- a/src/components/agents/email-agent-create-modal.tsx
+++ b/src/components/agents/email-agent-create-modal.tsx
@@ -93,7 +93,7 @@ export function EmailAgentCreateModal({ workspaceId }: EmailAgentCreateModalProp
 
             const payload = {
                 name: sessionName.trim(),
-                client_id: selectedClientId || null,
+                client_id: selectedClientId && selectedClientId !== 'none' ? selectedClientId : null,
                 client_name: selectedClient?.name || null,
                 email_subject: emailSubject.trim() || null,
                 email_type: emailType,

--- a/src/components/agents/tax-assistant-create-modal.tsx
+++ b/src/components/agents/tax-assistant-create-modal.tsx
@@ -84,7 +84,7 @@ export function TaxAssistantCreateModal({ workspaceId }: TaxAssistantCreateModal
 
             const payload = {
                 name: sessionName.trim(),
-                client_id: selectedClientId || null,
+                client_id: selectedClientId && selectedClientId !== 'none' ? selectedClientId : null,
                 client_name: selectedClient?.name || null,
             }
 

--- a/src/components/agents/tax-assistant-create-modal.tsx
+++ b/src/components/agents/tax-assistant-create-modal.tsx
@@ -166,7 +166,7 @@ export function TaxAssistantCreateModal({ workspaceId }: TaxAssistantCreateModal
                                     />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="">No client selected</SelectItem>
+                                    <SelectItem value="none">No client selected</SelectItem>
                                     {clients.map((client) => (
                                         <SelectItem key={client.id} value={client.id}>
                                             {client.name}

--- a/src/components/chat/tax-assistant-enhanced.tsx
+++ b/src/components/chat/tax-assistant-enhanced.tsx
@@ -162,7 +162,7 @@ export function TaxAssistantEnhanced() {
             // Prepare context for AI
             const context = {
                 session_id: activeSession.id,
-                client_id: selectedClient || null,
+                client_id: selectedClient && selectedClient !== 'none' ? selectedClient : null,
                 attached_documents: attachedDocuments,
                 workspace_id: workspaceId,
                 conversation_history: messages.slice(-5), // Last 5 messages for context
@@ -202,7 +202,7 @@ export function TaxAssistantEnhanced() {
         try {
             const sessionData = {
                 name: sessionName,
-                client_id: selectedClient || null,
+                client_id: selectedClient && selectedClient !== 'none' ? selectedClient : null,
                 workspace_id: workspaceId,
             }
 

--- a/src/components/chat/tax-assistant-enhanced.tsx
+++ b/src/components/chat/tax-assistant-enhanced.tsx
@@ -279,7 +279,7 @@ export function TaxAssistantEnhanced() {
                                 <SelectValue placeholder="Select client (optional)" />
                             </SelectTrigger>
                             <SelectContent>
-                                <SelectItem value="">No specific client</SelectItem>
+                                <SelectItem value="none">No specific client</SelectItem>
                                 {clients?.clients?.map((client) => (
                                     <SelectItem key={client.id} value={client.id}>
                                         {client.name}
@@ -624,7 +624,7 @@ export function TaxAssistantEnhanced() {
                                     <SelectValue placeholder="Select a client for context" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="">General tax questions</SelectItem>
+                                    <SelectItem value="none">General tax questions</SelectItem>
                                     {clients?.clients?.map((client) => (
                                         <SelectItem key={client.id} value={client.id}>
                                             {client.name}

--- a/src/components/email/email-agent-enhanced.tsx
+++ b/src/components/email/email-agent-enhanced.tsx
@@ -520,7 +520,7 @@ export function EmailAgentEnhanced() {
                                                 <SelectValue placeholder="Select client for context" />
                                             </SelectTrigger>
                                             <SelectContent>
-                                                <SelectItem value="">No specific client</SelectItem>
+                                                <SelectItem value="none">No specific client</SelectItem>
                                                 {clients?.clients?.map((client) => (
                                                     <SelectItem key={client.id} value={client.id}>
                                                         {client.name}

--- a/src/components/email/email-agent-enhanced.tsx
+++ b/src/components/email/email-agent-enhanced.tsx
@@ -296,7 +296,7 @@ export function EmailAgentEnhanced() {
                 prompt,
                 context: {
                     task: 'email_enhancement',
-                    client_id: selectedClient,
+                    client_id: selectedClient && selectedClient !== 'none' ? selectedClient : null,
                     workspace_id: workspaceId,
                 },
             })


### PR DESCRIPTION
## Purpose

Users were encountering a runtime error where Radix UI Select components were throwing an error: "A <Select.Item /> must have a value prop that is not an empty string." This was preventing the email agent and tax assistant components from rendering properly on the dashboard.

## Code Changes

- **Updated Select.Item values**: Changed empty string values (`""`) to `"none"` across all agent components
- **Updated client ID logic**: Modified conditional logic to check for both falsy values and the new `"none"` value when determining client_id
- **Components affected**:
  - `email-agent-create-modal.tsx`
  - `tax-assistant-create-modal.tsx` 
  - `tax-assistant-enhanced.tsx`
  - `email-agent-enhanced.tsx`

The fix ensures that Select components have valid non-empty string values while maintaining the same functional behavior for "no client selected" scenarios.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/acfaecf6bb244bb7a1d5150e322b7f66/pixel-hub)

👀 [Preview Link](https://acfaecf6bb244bb7a1d5150e322b7f66-pixel-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>acfaecf6bb244bb7a1d5150e322b7f66</projectId>-->
<!--<branchName>pixel-hub</branchName>-->