### PR TITLE
Update next-auth to v4.24.10 to fix constructor error

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "framer-motion": "11.5.4",
         "lucide-react": "^0.453.0",
         "next": "14.0.1",
-        "next-auth": "^4.24.7",
+        "next-auth": "^4.24.10",
         "next-themes": "^0.2.1",
         "react": "19.0.0-rc-65a56d0e-20241020",
         "react-day-picker": "8.10.1",


### PR DESCRIPTION
## Purpose
Fix the NextAuth.js constructor error that was preventing the application from running properly. The user encountered a `TypeError: next_dist_server_web_exports_next_request__WEBPACK_IMPORTED_MODULE_0__ is not a constructor` error when trying to run the development server, which was caused by version compatibility issues between Next.js 14.0.1 and the previous NextAuth.js version.

## Code changes
- Updated `next-auth` dependency from `^4.24.7` to `^4.24.10` in package.json
- This ensures compatibility with Next.js 14.x as recommended in the NextAuth.js documentation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/acfaecf6bb244bb7a1d5150e322b7f66/spark-sanctuary)

👀 [Preview Link](https://acfaecf6bb244bb7a1d5150e322b7f66-spark-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>acfaecf6bb244bb7a1d5150e322b7f66</projectId>-->
<!--<branchName>spark-sanctuary</branchName>-->